### PR TITLE
Allow /tz load for all markets.

### DIFF
--- a/Economy/Data/Scripts/Economy.scripts/Messages/MessageMarketManagePlayer.cs
+++ b/Economy/Data/Scripts/Economy.scripts/Messages/MessageMarketManagePlayer.cs
@@ -670,10 +670,10 @@
                             return;
                         }
 
-                        var market = EconomyScript.Instance.Data.Markets.FirstOrDefault(m => m.DisplayName.Equals(MarketName, StringComparison.InvariantCultureIgnoreCase) && m.MarketId == SenderSteamId);
+                        var market = EconomyScript.Instance.Data.Markets.FirstOrDefault(m => m.DisplayName.Equals(MarketName, StringComparison.InvariantCultureIgnoreCase));
                         if (market == null)
                         {
-                            MessageClientTextMessage.SendMessage(SenderSteamId, "TZ LOAD", "You do not have a market by that name.");
+                            MessageClientTextMessage.SendMessage(SenderSteamId, "TZ LOAD", "A market by that name does not exist.");
                             return;
                         }
 


### PR DESCRIPTION
This data is mostly already available to the player via /pricelist, but it allows the player to copy the info into a spreadsheet.
[Economy] LCDs are frequently ambiguous, and are not in a machine readable format.
This also requires manual interaction.