### PR TITLE
Added invisible tabs to [Economy] lcd to deduplicate

### DIFF
--- a/Economy/Data/Scripts/Economy.scripts/Management/LcdManager.cs
+++ b/Economy/Data/Scripts/Economy.scripts/Management/LcdManager.cs
@@ -308,22 +308,22 @@
 
                     if (showPrices && showStock)
                     {
-                        writer.AddPublicRightText(buyColumn, showBuy.ToString("0.000", EconomyScript.ServerCulture));
-                        writer.AddPublicRightText(sellColumn, showSell.ToString("0.000", EconomyScript.ServerCulture));
+                        writer.AddPublicRightText(buyColumn, showBuy.ToString("\t0.000", EconomyScript.ServerCulture));
+                        writer.AddPublicRightText(sellColumn, showSell.ToString("\t0.000", EconomyScript.ServerCulture));
 
                         // TODO: components and tools should be displayed as whole numbers. Will be hard to align with other values.
-                        writer.AddPublicRightText(stockColumn, kvp.Key.Quantity.ToString("0.0000", EconomyScript.ServerCulture)); // TODO: recheck number of decimal places.
+                        writer.AddPublicRightText(stockColumn, kvp.Key.Quantity.ToString("\t0.0000", EconomyScript.ServerCulture)); // TODO: recheck number of decimal places.
                     }
                     else if (showStock) //does this ever actually run? seems to already be in the above?
                     {
                         // TODO: components and tools should be displayed as whole numbers. Will be hard to align with other values.
 
-                        writer.AddPublicRightText(stockColumn, kvp.Key.Quantity.ToString("0.0000", EconomyScript.ServerCulture)); // TODO: recheck number of decimal places.
+                        writer.AddPublicRightText(stockColumn, kvp.Key.Quantity.ToString("\t0.0000", EconomyScript.ServerCulture)); // TODO: recheck number of decimal places.
                     }
                     else if (showPrices)
                     {
-                        writer.AddPublicRightText(buyColumn, showBuy.ToString("0.000", EconomyScript.ServerCulture));
-                        writer.AddPublicRightText(sellColumn, showSell.ToString("0.000", EconomyScript.ServerCulture));
+                        writer.AddPublicRightText(buyColumn, showBuy.ToString("\t0.000", EconomyScript.ServerCulture));
+                        writer.AddPublicRightText(sellColumn, showSell.ToString("\t0.000", EconomyScript.ServerCulture));
                     }
                     writer.AddPublicLine();
                 }


### PR DESCRIPTION
Sometime [Economy] lcd have ambiguous content when any of the fields is too long.
E.g.
Uranium Ingot                                500000.00079228162514264337593543950335.0000.0000

This makes the data ambiguous.
From a display perspective, it might be better to change the pattern to display engineering notation when needed to prevent overflows.
Because SE LCD do not render tabs, adding them does not effect the visuals, but it also opens up the possibility to copy and paste the content into spread sheet and/or parse them using an in game script.